### PR TITLE
add no-restricted-imports rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Then configure the rules you want to use under the rules section.
 
 | Rule                                  | Description |
 |---------------------------------------|-------------|
+| `amd-imports/no-restricted-imports`   | Restrict modules that can be imported. |
 | `amd-imports/no-unexisting-imports`   | Verify that imported modules exist. See [Resolving Modules](#resolving-modules) for details. |
 | `amd-imports/no-unused-imports`       | Verify that imported modules are used. If a module is imported because it has side effects, the imported module variable name may have the `_` prefix or suffix to skip this rule. |
 | `amd-imports/prefer-relative-imports` | Prefer relative imports within a single package instead of top-level package absolute imports. |
@@ -65,7 +66,18 @@ Then configure the rules you want to use under the rules section.
         // A list of modules assumed to be present globally.
         // This is in addition to the modules assumed always
         // to be global: require, define, module, exports
-        "globals": []
+        "globals": [],
+
+        // A list of modules restricted from use
+        // Can be an array of strings for module names
+        // or an object with the name and a custom message.
+        "restricted": [
+            "path/to/module",
+            {
+                "name": "path/to/module",
+                "message": "Please use an alternative module"
+            }
+        ]
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Then configure the rules you want to use under the rules section.
             "path/to/module",
             {
                 "name": "path/to/module",
-                "message": "Please use an alternative module"
+                "message": "Please use an alternative module",
+                "replaceWith": "use/this/module" // custom fixer
             }
         ]
     }

--- a/index.js
+++ b/index.js
@@ -2,11 +2,13 @@
 
 module.exports = {
   rules: {
+    'no-restricted-imports': require('./lib/rules/no-restricted-imports'),
     'no-unexisting-imports': require('./lib/rules/no-unexisting-imports'),
     'no-unused-imports': require('./lib/rules/no-unused-imports'),
     'prefer-relative-imports': require('./lib/rules/prefer-relative-imports')
   },
   rulesConfig: {
+    'no-restricted-imports': 2,
     'no-unexisting-imports': 2,
     'no-unused-imports': 2,
     'prefer-relative-imports': 2

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -1,0 +1,60 @@
+'use strict';
+
+let match = require('../match');
+
+module.exports = {
+  meta: {
+  },
+
+  create: function(context) {
+    return {
+      'Program:exit': function(node) {
+        let define = match.define(node);
+
+        if (!define) {
+          return;
+        }
+
+        let restricted = context.settings['amd-imports'].restricted || [];
+
+        let modulePaths = define.modulePaths.filter(element => {
+          return (
+            element.type === 'Literal' &&
+            (element.raw[0] === '\'' || element.raw[0] === '"')
+          );
+        });
+
+        modulePaths.forEach(modulePath => {
+          let importPath = modulePath.value;
+          if (importPath === '') {
+            // Skip
+            return;
+          }
+
+          restricted.forEach(restrictedModule => {
+            if (typeof restrictedModule === 'string') {
+              if (restrictedModule === importPath) {
+                context.report({
+                  node: modulePath,
+                  message: 'Restricted import \'' + importPath + '\''
+                });
+              }
+            }
+            else if (typeof restrictedModule === 'object') {
+              if (restrictedModule.name && restrictedModule.name === importPath) {
+                context.report({
+                  node: modulePath,
+                  message: restrictedModule.message ?
+                  'Restricted import \'' + importPath + '\'' + ' - ' + restrictedModule.message
+                  :
+                  'Restricted import \'' + importPath + '\''
+                });
+              }
+            }
+
+          });
+        });
+      }
+    };
+  }
+};

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -4,6 +4,7 @@ let match = require('../match');
 
 module.exports = {
   meta: {
+    fixable: "code"
   },
 
   create: function(context) {
@@ -32,6 +33,7 @@ module.exports = {
           }
 
           restricted.forEach(restrictedModule => {
+            let replaceWith = restrictedModule.replaceWith;
             if (typeof restrictedModule === 'string') {
               if (restrictedModule === importPath) {
                 context.report({
@@ -42,13 +44,17 @@ module.exports = {
             }
             else if (typeof restrictedModule === 'object') {
               if (restrictedModule.name && restrictedModule.name === importPath) {
-                context.report({
+                let report = {
                   node: modulePath,
                   message: restrictedModule.message ?
                   'Restricted import \'' + importPath + '\'' + ' - ' + restrictedModule.message
                   :
                   'Restricted import \'' + importPath + '\''
-                });
+                };
+                if (replaceWith) {
+                  report.fix = fixer => fixer.replaceText(modulePath, '"' + replaceWith + '"');
+                }
+                context.report(report);
               }
             }
 


### PR DESCRIPTION
Adds a new rule for `amd-imports/no-restricted-modules` to ban the use of AMD modules.

This lets me do something like this:

```json
  "settings": {
    "amd-imports": {
     "restricted" : [
      "dont/use/me",
      {
        "name": "dont/use/me-either",
        "message": "Please don't use this",
        "replaceWith": "use/this/module" // custom fixer
      }
     ]
    }
  },
```

My first crack at an ESLint plugin, seems to be working locally so far.